### PR TITLE
Fix bug: 'application/json' being appended to content-type for each request

### DIFF
--- a/lib/fluent/plugin/out_loggly.rb
+++ b/lib/fluent/plugin/out_loggly.rb
@@ -52,7 +52,7 @@ class LogglyOutput < Fluent::Output
       begin
         response = @http.request @uri, post
         $log.debug "HTTP Response code #{response.code}"
-        $log.error response.message if response.code != "200"
+        $log.error response.body if response.code != "200"
       rescue
         $log.error "Error connecting to loggly verify the url #{@loggly_url}"
       end


### PR DESCRIPTION
As per the documentation in http://docs.seattlerb.org/net-http-persistent/Net/HTTP/Persistent.html

> Headers may be specified for use in every request. headers are **appended** to any headers on the request. override_headers replace existing headers on the request.
> 
> The difference between the two can be seen in setting the User-Agent. Using http.headers['User-Agent'] = 'MyUserAgent' will send “Ruby, MyUserAgent” while http.override_headers['User-Agent'] = 'MyUserAgent' will send “MyUserAgent”.

When doing @http.request, the @post is modified and content type appended. With many requests, this results in huge headers and in HTTP 400 errors by fluent ("request headers too large").

This PR fixes that, making sure the post is instantiated every time.
