### PR TITLE
Add a link to fluentd.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Loggly plugin for Fluentd
+Loggly plugin for [Fluentd](http://fluentd.org)
 =============
 With fluent-plugin-loggly you will be able to use the service loggly.com as output for you fluentd logs.
 


### PR DESCRIPTION
I am adding a link to Fluentd.org in your README.md file to put Fluentd in context for newcomers.
