### PR TITLE
Use Yajl to try to avoid JSON encoding errors

### DIFF
--- a/lib/fluent/plugin/out_loggly.rb
+++ b/lib/fluent/plugin/out_loggly.rb
@@ -1,6 +1,6 @@
 =begin
-  
-  Copyright (C) 2012 Patrik Antonsson 
+
+  Copyright (C) 2012 Patrik Antonsson
 
   Licensed to the Apache Software Foundation (ASF) under one
   or more contributor license agreements.  See the NOTICE file
@@ -45,7 +45,7 @@ class LogglyOutput < Fluent::Output
   def emit(tag, es, chain)
     chain.next
     es.each {|time,record|
-      record_json = record.to_json
+      record_json = Yajl::Encoder.encode(record)
       $log.debug "Record sent #{record_json}"
       post = Net::HTTP::Post.new @uri.path
       post.body = record_json

--- a/lib/fluent/plugin/out_loggly_buffered.rb
+++ b/lib/fluent/plugin/out_loggly_buffered.rb
@@ -55,7 +55,7 @@ class LogglyOutputBuffred < Fluent::BufferedOutput
     records = []
     chunk.msgpack_each {|tag,time,record|
       record['timestamp'] ||= Time.at(time).iso8601 if @output_include_time
-      records.push(record.to_json)
+      records.push(Yajl::Encoder.encode(record))
     }
     $log.debug "#{records.length} records sent"
     post = Net::HTTP::Post.new @uri.path


### PR DESCRIPTION
See uken/fluent-plugin-elasticsearch#19

Replaces #11 as per [this comment](https://github.com/patant/fluent-plugin-loggly/pull/11#issuecomment-153044844)