### PR TITLE
Set default buffer_chunk_limit

### DIFF
--- a/lib/fluent/plugin/out_loggly_buffered.rb
+++ b/lib/fluent/plugin/out_loggly_buffered.rb
@@ -25,6 +25,7 @@ class LogglyOutputBuffred < Fluent::BufferedOutput
   Fluent::Plugin.register_output('loggly_buffered', self)
   config_param :loggly_url, :string, :default => nil
   config_param :output_include_time, :bool, :default => true  # Recommended
+  config_set_default :buffer_chunk_limit, 5*1024*1024  # overwrite default buffer_chunk_limit
 
   unless method_defined?(:log)
     define_method("log") { $log }


### PR DESCRIPTION
According to [Loggly's documentation](https://www.loggly.com/docs/troubleshooting-http/):

> If you get the error “413 Request Entity Too Large”, it means your file size is larger than the limit of 5MB. Please split your file into chunks less than 5MB, or curl the file one line at a time.

So let's overwrite the `buffer_chunk_limit` param, which is default to 8MB by fluentd.
