### PR TITLE
Enable sub-second precision on timestamp output

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ or if you want to use buffered plugin:
       type loggly_buffered
       loggly_url https://logs-01.loggly.com/bulk/xxx-xxxx-xxxx-xxxxx-xxxxxxxxxx
       output_include_time true  # add 'timestamp' record into log. (default: true)
+      time_precision_digits 3 # Include 3 digits of sub-second precision (default: 0)
       buffer_type    file
       buffer_path    /path/to/buffer/file
       flush_interval 10s


### PR DESCRIPTION
With fluentd 0.14 supporting sub-second time fields, I'd like to get the loggly plugin to support outputting those.

Updated: I've tested this in my cluster with success.  I'm seeing milliseconds in loggly by setting ```time_precision_digits``` to 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/patant/fluent-plugin-loggly/16)
<!-- Reviewable:end -->
