### PR TITLE
Add timestamp to non-buffered records

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ With fluent-plugin-loggly you will be able to use [Loggly](http://loggly.com) as
     <match your_match>
       type loggly
       loggly_url https://logs-01.loggly.com/inputs/xxx-xxxx-xxxx-xxxxx-xxxxxxxxxx
+      output_include_time true  # add 'timestamp' record into log. (default: true)
     </match>
 ~~~~~
 or if you want to use buffered plugin:
@@ -27,7 +28,7 @@ or if you want to use buffered plugin:
       flush_interval 10s
     </match>
 ~~~~~
-   
+
 Note that buffered plugin uses bulk import to improve performance, so make sure to set Bulk endpoint to loggly_url.
 
 The `xxx-xxxx...` is your Loggly access token.

--- a/lib/fluent/plugin/out_loggly.rb
+++ b/lib/fluent/plugin/out_loggly.rb
@@ -24,6 +24,7 @@
 class LogglyOutput < Fluent::Output
   Fluent::Plugin.register_output('loggly', self)
   config_param :loggly_url, :string, :default => nil
+  config_param :output_include_time, :bool, :default => true  # Recommended
 
   def configure(conf)
     super
@@ -45,6 +46,7 @@ class LogglyOutput < Fluent::Output
   def emit(tag, es, chain)
     chain.next
     es.each {|time,record|
+      record['timestamp'] ||= Time.at(time).iso8601 if @output_include_time
       record_json = Yajl::Encoder.encode(record)
       $log.debug "Record sent #{record_json}"
       post = Net::HTTP::Post.new @uri.path


### PR DESCRIPTION
Because they can be valueable as well. For example if you feed entries from _syslog_ you want to keep the original timestamps and send them to Loggly.

wdyt?
