### PR TITLE
Pessimistic version constraints for rubygems dependencies

### DIFF
--- a/fluent-plugin-loggly.gemspec
+++ b/fluent-plugin-loggly.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   s.required_ruby_version = Gem::Requirement.new(">= 1.9.3")
-  s.add_dependency('net-http-persistent', '>= 2.7')
-  s.add_dependency('yajl-ruby', '>= 1.0')
+  s.add_dependency('net-http-persistent', '~> 2.7')
+  s.add_dependency('yajl-ruby', '~> 1.0')
 end


### PR DESCRIPTION
Yesterday [net-http-persistent](https://github.com/drbrain/net-http-persistent) version v3.0.0  was released, which breaks backwards compatibility, and thus breaks this plugin.
How about using pessimistic version constraints, so we don't automatically update to the next major version?

cc @cargomedia/devops
